### PR TITLE
Use https rather than git protocal

### DIFF
--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -68,7 +68,7 @@ if(NOT Sopt_FOUND)
 endif()
 lookup_package(
     Sopt REQUIRED ARGUMENTS
-    GIT_REPOSITORY git@github.com:basp-group/sopt.git
+    GIT_REPOSITORY https://www.github.com/basp-group/sopt.git
     GIT_TAG ${sopt_tag})
 
 lookup_package(CFitsIO REQUIRED ARGUMENTS CHECKCASA)


### PR DESCRIPTION
Makes it simpler to download since we do not need keys to be setup.
