### PR TITLE
Wrong name for libpurify

### DIFF
--- a/cpp/purify/CMakeLists.txt
+++ b/cpp/purify/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(libpurify SHARED ${SOURCES})
 set(version "${Purify_VERSION_MAJOR}.${Purify_VERSION_MINOR}.${Purify_VERSION_PATCH}")
 set(soversion "${Purify_VERSION_MAJOR}.${Purify_VERSION_MINOR}")
 set_target_properties(libpurify PROPERTIES VERSION ${version} SOVERSION ${soversion})
+set_target_properties(libpurify PROPERTIES OUTPUT_NAME purify)
 
 target_include_directories(libpurify PUBLIC
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>


### PR DESCRIPTION
Closes basp-group/purify#9
