### PR TITLE
Add include to fix MPI guard bug

### DIFF
--- a/cpp/benchmarks/main.cc
+++ b/cpp/benchmarks/main.cc
@@ -1,6 +1,7 @@
 #include <benchmark/benchmark.h>
 #include <sopt/mpi/communicator.h>
 #include <sopt/mpi/session.h>
+#include "purify/config.h"
 
 // This reporter does nothing.
 // We can use it to disable output from all but the root process


### PR DESCRIPTION
Hack to the benchmark MPI build.