### PR TITLE
Set communicator for wavelet operator benchmarks

### DIFF
--- a/cpp/benchmarks/utilities.cc
+++ b/cpp/benchmarks/utilities.cc
@@ -178,5 +178,6 @@ std::tuple<utilities::vis_params, t_real> dirty_measurements(
   auto const sigma = comm.broadcast<t_real>();
   return std::make_tuple(utilities::scatter_visibilities(comm), sigma);
 }
+void update_comm(sopt::mpi::Communicator &comm) { comm = sopt::mpi::Communicator::World(); }
 #endif
 }  // namespace b_utilities

--- a/cpp/benchmarks/utilities.h
+++ b/cpp/benchmarks/utilities.h
@@ -41,7 +41,7 @@ std::tuple<utilities::vis_params, t_real> dirty_measurements(
     const t_real& cellsize, sopt::mpi::Communicator const& comm);
 utilities::vis_params random_measurements(t_int size, sopt::mpi::Communicator const& comm);
 
-void update_comm(sopt::mpi::Communicator & comm);
+void update_comm(sopt::mpi::Communicator& comm);
 
 #endif
 }  // namespace b_utilities

--- a/cpp/benchmarks/utilities.h
+++ b/cpp/benchmarks/utilities.h
@@ -41,6 +41,8 @@ std::tuple<utilities::vis_params, t_real> dirty_measurements(
     const t_real& cellsize, sopt::mpi::Communicator const& comm);
 utilities::vis_params random_measurements(t_int size, sopt::mpi::Communicator const& comm);
 
+void update_comm(sopt::mpi::Communicator & comm);
+
 #endif
 }  // namespace b_utilities
 

--- a/cpp/benchmarks/wavelet_operator_mpi.cc
+++ b/cpp/benchmarks/wavelet_operator_mpi.cc
@@ -2,6 +2,8 @@
 #include <benchmark/benchmark.h>
 #include "benchmarks/utilities.h"
 #include "purify/wavelet_operator_factory.h"
+#include <sopt/mpi/communicator.h>
+#include <sopt/mpi/session.h>
 
 using namespace purify;
 
@@ -48,7 +50,22 @@ using namespace purify;
 
 class WaveletOperatorMPIFixture : public ::benchmark::Fixture {
  public:
-  void SetUp(const ::benchmark::State& state) {}
+  WaveletOperatorMPIFixture(){};
+  void SetUp(const ::benchmark::State& state) {
+    m_imsizex = state.range(0);
+    m_imsizey = state.range(0);
+
+    sopt::wavelets::SARA m_sara{
+        std::make_tuple("Dirac", 3u), std::make_tuple("DB1", 3u), std::make_tuple("DB2", 3u),
+        std::make_tuple("DB3", 3u),   std::make_tuple("DB4", 3u), std::make_tuple("DB5", 3u),
+        std::make_tuple("DB6", 3u),   std::make_tuple("DB7", 3u), std::make_tuple("DB8", 3u)};
+
+    sopt::wavelets::SARA const saraDistr = sopt::wavelets::distribute_sara(m_sara, m_world);
+
+    // Get the number of wavelet coefs
+    n_wave_coeff = saraDistr.size() * m_imsizey * m_imsizex;
+    m_Psi = sopt::linear_transform<t_complex>(saraDistr, m_imsizey, m_imsizex, m_world);
+  }
 
   void TearDown(const ::benchmark::State& state) {}
 
@@ -56,39 +73,15 @@ class WaveletOperatorMPIFixture : public ::benchmark::Fixture {
   t_uint m_counter;
   // MPI communicator
   sopt::mpi::Communicator m_world;
-};
-
-class WaveletOperatorAdjointMPIFixture : public ::benchmark::Fixture {
- public:
-  void SetUp(const ::benchmark::State& state) {}
-
-  void TearDown(const ::benchmark::State& state) {}
-
-  // A bunch of useful variables
-  t_uint m_counter;
-  // MPI communicator
-  sopt::mpi::Communicator m_world;
-};
-
-BENCHMARK_DEFINE_F(WaveletOperatorMPIFixture, Apply)(benchmark::State& state) {
-  // Image size
-  t_uint m_imsizex = state.range(0);
-  t_uint m_imsizey = state.range(0);
-
-  sopt::wavelets::SARA m_sara{
-      std::make_tuple("Dirac", 3u), std::make_tuple("DB1", 3u), std::make_tuple("DB2", 3u),
-      std::make_tuple("DB3", 3u),   std::make_tuple("DB4", 3u), std::make_tuple("DB5", 3u),
-      std::make_tuple("DB6", 3u),   std::make_tuple("DB7", 3u), std::make_tuple("DB8", 3u)};
-
-  sopt::wavelets::SARA const saraDistr = sopt::wavelets::distribute_sara(m_sara, m_world);
-
-  sopt::LinearTransform<Vector<t_complex>> m_Psi =
-      sopt::linear_transform<t_complex>(saraDistr, m_imsizey, m_imsizex, m_world);
-
-  // Benchmark the application of the operator
-
+  sopt::LinearTransform<Vector<t_complex>> m_Psi = sopt::linear_transform_identity<t_complex>();
+  t_uint m_imsizex;
+  t_uint m_imsizey;
   // Get the number of wavelet coefs
-  t_uint const n_wave_coeff = saraDistr.size() * m_imsizey * m_imsizex;
+  t_uint n_wave_coeff;
+};
+
+BENCHMARK_DEFINE_F(WaveletOperatorMPIFixture, Forward)(benchmark::State& state) {
+  // Benchmark the application of the operator
 
   // Apply Psi to a temporary vector
   Vector<t_complex> image = Vector<t_complex>::Random(m_imsizey * m_imsizex);
@@ -102,25 +95,8 @@ BENCHMARK_DEFINE_F(WaveletOperatorMPIFixture, Apply)(benchmark::State& state) {
   }
 }
 
-BENCHMARK_DEFINE_F(WaveletOperatorAdjointMPIFixture, Apply)(benchmark::State& state) {
-  // Image size
-  t_uint m_imsizex = state.range(0);
-  t_uint m_imsizey = state.range(0);
+BENCHMARK_DEFINE_F(WaveletOperatorMPIFixture, Adjoint)(benchmark::State& state) {
 
-  sopt::wavelets::SARA m_sara{
-      std::make_tuple("Dirac", 3u), std::make_tuple("DB1", 3u), std::make_tuple("DB2", 3u),
-      std::make_tuple("DB3", 3u),   std::make_tuple("DB4", 3u), std::make_tuple("DB5", 3u),
-      std::make_tuple("DB6", 3u),   std::make_tuple("DB7", 3u), std::make_tuple("DB8", 3u)};
-
-  sopt::wavelets::SARA const saraDistr = sopt::wavelets::distribute_sara(m_sara, m_world);
-
-  sopt::LinearTransform<Vector<t_complex>> m_Psi =
-      sopt::linear_transform<t_complex>(saraDistr, m_imsizey, m_imsizex, m_world);
-
-  // Benchmark the application of the operator
-
-  // Get the number of wavelet coefs
-  t_uint const n_wave_coeff = saraDistr.size() * m_imsizey * m_imsizex;
 
   // Apply Psi to a temporary vector
   Vector<t_complex> const image = Vector<t_complex>::Ones(m_imsizey * m_imsizex);
@@ -134,7 +110,7 @@ BENCHMARK_DEFINE_F(WaveletOperatorAdjointMPIFixture, Apply)(benchmark::State& st
   }
 }
 
-BENCHMARK_REGISTER_F(WaveletOperatorMPIFixture, Apply)
+BENCHMARK_REGISTER_F(WaveletOperatorMPIFixture, Forward)
     // //->Apply(b_utilities::Arguments)
     ->RangeMultiplier(2)
     ->Range(128, 128 << 3)
@@ -143,7 +119,7 @@ BENCHMARK_REGISTER_F(WaveletOperatorMPIFixture, Apply)
     ->ReportAggregatesOnly(true)
     ->Unit(benchmark::kMillisecond);
 
-BENCHMARK_REGISTER_F(WaveletOperatorAdjointMPIFixture, Apply)
+BENCHMARK_REGISTER_F(WaveletOperatorMPIFixture, Adjoint)
     // //->Apply(b_utilities::Arguments)
     ->RangeMultiplier(2)
     ->Range(128, 128 << 3)

--- a/cpp/benchmarks/wavelet_operator_mpi.cc
+++ b/cpp/benchmarks/wavelet_operator_mpi.cc
@@ -96,8 +96,6 @@ BENCHMARK_DEFINE_F(WaveletOperatorMPIFixture, Forward)(benchmark::State& state) 
 }
 
 BENCHMARK_DEFINE_F(WaveletOperatorMPIFixture, Adjoint)(benchmark::State& state) {
-
-
   // Apply Psi to a temporary vector
   Vector<t_complex> const image = Vector<t_complex>::Ones(m_imsizey * m_imsizex);
   Vector<t_complex> wavelet_coeff = Vector<t_complex>::Zero(n_wave_coeff);

--- a/cpp/benchmarks/wavelet_operator_mpi.cc
+++ b/cpp/benchmarks/wavelet_operator_mpi.cc
@@ -54,7 +54,7 @@ class WaveletOperatorMPIFixture : public ::benchmark::Fixture {
   void SetUp(const ::benchmark::State& state) {
     m_imsizex = state.range(0);
     m_imsizey = state.range(0);
-
+    b_utilities::update_comm(m_world);
     sopt::wavelets::SARA m_sara{
         std::make_tuple("Dirac", 3u), std::make_tuple("DB1", 3u), std::make_tuple("DB2", 3u),
         std::make_tuple("DB3", 3u),   std::make_tuple("DB4", 3u), std::make_tuple("DB5", 3u),

--- a/cpp/benchmarks/wavelet_operator_mpi.cc
+++ b/cpp/benchmarks/wavelet_operator_mpi.cc
@@ -87,11 +87,11 @@ BENCHMARK_DEFINE_F(WaveletOperatorMPIFixture, Forward)(benchmark::State& state) 
   Vector<t_complex> image = Vector<t_complex>::Random(m_imsizey * m_imsizex);
   Vector<t_complex> const wavelet_coeff = Vector<t_complex>::Ones(n_wave_coeff);
 
-  while (state.KeepRunning()) {
+  while (m_world.broadcast<int>(state.KeepRunning())) {
     auto start = std::chrono::high_resolution_clock::now();
     image = m_Psi * wavelet_coeff;
     auto end = std::chrono::high_resolution_clock::now();
-    state.SetIterationTime(b_utilities::duration(start, end));
+    state.SetIterationTime(b_utilities::duration(start, end, m_world));
   }
 }
 
@@ -102,11 +102,11 @@ BENCHMARK_DEFINE_F(WaveletOperatorMPIFixture, Adjoint)(benchmark::State& state) 
   Vector<t_complex> const image = Vector<t_complex>::Ones(m_imsizey * m_imsizex);
   Vector<t_complex> wavelet_coeff = Vector<t_complex>::Zero(n_wave_coeff);
 
-  while (state.KeepRunning()) {
+  while (m_world.broadcast<int>(state.KeepRunning())) {
     auto start = std::chrono::high_resolution_clock::now();
     wavelet_coeff = m_Psi.adjoint() * image;
     auto end = std::chrono::high_resolution_clock::now();
-    state.SetIterationTime(b_utilities::duration(start, end));
+    state.SetIterationTime(b_utilities::duration(start, end, m_world));
   }
 }
 


### PR DESCRIPTION
Fixed a bug where communicator was not set. This had to be done using a function, since benchmark fixtures are static (initialised before main() and MPI).

Also made code more compact.