### PR TITLE
Build documentation using docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -182,15 +182,8 @@ matrix:
         - TEST_CMD=''
 
     - os: linux
-      addons:
-        apt:
-          sources:
-            - *basic_sources
-          packages:
-            - *native_deps
-            - *all_deps
-            - doxygen # version 1.8.6-2
-            - graphviz # version 2.36.0
+      services:
+        - docker
       env:
         - TITLE="Documentation - GCC"
         - DEBUG=True
@@ -251,6 +244,12 @@ before_install:
   - echo "==================== ${TITLE} ====================="
   - if [[ $MPI = ON ]]; then if [ $TRAVIS_OS_NAME = linux ]; then  if [[ ${TITLE} != *mpich* ]]; then bash .ci/build_openmpi.sh; MPI_EXTRA="--oversubscribe"; export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH; else bash .ci/build_mpich.sh; fi; fi; fi;
   - if [[ $MPI = ON ]]; then eval $MPI_CONFIG; echo $CMAKE_CMD_EXTRA;  fi
+  - |
+    if [[ ${TITLE} = *Documentation* ]]; then
+        docker pull uclrits/sopt
+        docker run -it --name sopt -v $(pwd):/mydata uclrits/sopt
+    fi
+
 
 install:
 
@@ -286,6 +285,7 @@ script:
   - eval $BUILD_CMD
   - eval $TEST_CMD
   - if [[ ${TITLE} != *Documentation* ]] && [[ ${TITLE} != *Lint* ]]; then sudo make install; fi
+  - if [[ ${TITLE} = *Documentation* ]]; then exit; fi
 
 after_success:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,6 +187,8 @@ matrix:
         - DOCS=ON
         - BUILD_CMD='make doc VERBOSE=1'
         - TEST_CMD=''
+      script:
+        - docker run --rm -v $(pwd):/mydata uclrits/sopt /bin/sh -c "mkdir build; cd build; cmake .. -Ddocs=${DOCS}; eval ${BUILD_CMD}"
 
     - os: linux
       addons:
@@ -240,7 +242,6 @@ before_install:
   - |
     if [[ ${TITLE} = *Documentation* ]]; then
         docker pull uclrits/sopt
-        docker run -it --name sopt -v $(pwd):/mydata uclrits/sopt
     fi
 
 
@@ -278,7 +279,6 @@ script:
   - eval $BUILD_CMD
   - eval $TEST_CMD
   - if [[ ${TITLE} != *Documentation* ]] && [[ ${TITLE} != *Lint* ]]; then sudo make install; fi
-  - if [[ ${TITLE} = *Documentation* ]]; then exit; fi
 
 after_success:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,6 @@ env:
 # The apt packages below are needed but can no longer be installed with
 # sudo apt-get.
 addons:
-  apt:
-    sources: &basic_sources
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
-    packages: &native_deps
-      - g++-7
-      - clang-5.0
-      - libtiff5-dev # version 5 ?
-      - libgomp1 # version 4.8.4-2
-      - libfftw3-dev # version 3.3.3
   homebrew:
     packages: &osx_sources
       - gcc@7
@@ -67,10 +57,13 @@ matrix:
     - os: linux
       addons:
         apt:
-          sources:
-            - *basic_sources
+          sources: &basic_sources
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
           packages:
-            - *native_deps
+            - &native_deps [ g++-7, clang-5.0, libtiff5-dev, libgomp1, libfftw3-dev ]
+            # libtiff5-dev version 5 ?; libgomp1 version 4.8.4-2
+            # libfftw3-dev version 3.3.3
             - &all_deps [ libboost-all-dev, libeigen3-dev, libyaml-cpp-dev ]
             # libboost-all-dev version 1.54; libeigen3-dev version 3.2.0
             # libcfitsio3-dev version 3.34; libyaml-cpp-dev version 0.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -188,6 +188,7 @@ matrix:
         - BUILD_CMD='make doc VERBOSE=1'
         - TEST_CMD=''
       script:
+        - chmod o+w . # To allow docker to create the build directory
         - docker run --rm -v $(pwd):/mydata uclrits/sopt /bin/sh -c "mkdir build; cd build; cmake .. -Ddocs=${DOCS}; eval ${BUILD_CMD}"
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -179,14 +179,8 @@ matrix:
         - docker
       env:
         - TITLE="Documentation - GCC"
-        - DEBUG=True
-        - LDFLAGS='-pthread'
-        - Tests=OFF
-        - MPI=OFF
-        - openMP=OFF
         - DOCS=ON
         - BUILD_CMD='make doc VERBOSE=1'
-        - TEST_CMD=''
       script:
         - chmod o+w . # To allow docker to create the build directory
         - docker run --rm -v $(pwd):/mydata uclrits/sopt /bin/sh -c "mkdir build; cd build; cmake .. -Ddocs=${DOCS}; eval ${BUILD_CMD}"
@@ -240,10 +234,7 @@ before_install:
   - echo "==================== ${TITLE} ====================="
   - if [[ $MPI = ON ]]; then if [ $TRAVIS_OS_NAME = linux ]; then  if [[ ${TITLE} != *mpich* ]]; then bash .ci/build_openmpi.sh; MPI_EXTRA="--oversubscribe"; export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH; else bash .ci/build_mpich.sh; fi; fi; fi;
   - if [[ $MPI = ON ]]; then eval $MPI_CONFIG; echo $CMAKE_CMD_EXTRA;  fi
-  - |
-    if [[ ${TITLE} = *Documentation* ]]; then
-        docker pull uclrits/sopt
-    fi
+  - if [[ ${TITLE} = *Documentation* ]]; then docker pull uclrits/sopt; fi
 
 
 install:


### PR DESCRIPTION
The docs are not as nice as they should because the version of doxygen on trusty is not as new as it could be. This PR changes travis docs to use sopt docker container (which includes latest doxygen) to build the documentation.
