### PR TITLE
fixed requirements for using the dual forward backward algorithm 

### DIFF
--- a/cpp/main.cc
+++ b/cpp/main.cc
@@ -237,8 +237,9 @@ int main(int argc, const char **argv) {
         params.mpiAlgorithm(), measurements_transform, wavelets_transform, uv_data,
         sigma * params.epsilonScaling() / flux_scale, params.height(), params.width(), sara_size,
         params.iterations(), params.realValueConstraint(), params.positiveValueConstraint(),
-        (params.wavelet_basis().size() < 2), params.relVarianceConvergence(),
-        params.dualFBVarianceConvergence(), 50);
+        (params.wavelet_basis().size() < 2) and (not params.realValueConstraint()) and
+            (not params.positiveValueConstraint()),
+        params.relVarianceConvergence(), params.dualFBVarianceConvergence(), 50);
   if (params.algorithm() == "fb")
     fb = factory::fb_factory<sopt::algorithm::ImagingForwardBackward<t_complex>>(
         params.mpiAlgorithm(), measurements_transform, wavelets_transform, uv_data,
@@ -246,8 +247,9 @@ int main(int argc, const char **argv) {
         params.stepsize() * std::pow(sigma * params.epsilonScaling() / flux_scale, 2),
         params.regularisation_parameter(), params.height(), params.width(), sara_size,
         params.iterations(), params.realValueConstraint(), params.positiveValueConstraint(),
-        (params.wavelet_basis().size() < 2), params.relVarianceConvergence(),
-        params.dualFBVarianceConvergence(), 50);
+        (params.wavelet_basis().size() < 2) and (not params.realValueConstraint()) and
+            (not params.positiveValueConstraint()),
+        params.relVarianceConvergence(), params.dualFBVarianceConvergence(), 50);
 
   // Save some things before applying the algorithm
   // the config yaml file - this also generates the output directory and the timestamp


### PR DESCRIPTION
Found that the positivity and real valued requirements need padmm and fb to use a non-tight frame. This means we also need to use the dual forward backward method in these cases. This has been added to main.cc