### PR TITLE
Widefield bug fix

### DIFF
--- a/cpp/purify/wide_field_utilities.cc
+++ b/cpp/purify/wide_field_utilities.cc
@@ -19,7 +19,9 @@ t_real estimate_cell_size(const t_real max_u, const t_uint imsize, const t_real 
 
 t_real fov_cosine(t_real const cell, t_uint const imsize) {
   const t_real theta_FoV_L = imsize * cell;
-  return 2 * std::sin(constant::pi / 180. * theta_FoV_L / (60. * 60.) * 0.5);
+  const t_real extra_theta = (theta_FoV_L > 180. * 60. * 60.) ? theta_FoV_L - 180. * 60. * 60. : 0.;
+  return 2 * std::sin(constant::pi / 180. * (theta_FoV_L - extra_theta) / (60. * 60.) * 0.5) +
+         2 * std::sin(constant::pi / 180. * extra_theta / (60. * 60.) * 0.5);
 }
 
 Matrix<t_complex> generate_chirp(const t_real w_rate, const t_real cell_x, const t_real cell_y,

--- a/cpp/purify/wide_field_utilities.h
+++ b/cpp/purify/wide_field_utilities.h
@@ -29,7 +29,7 @@ Matrix<t_complex> generate_dde(const DDE &dde, const t_real cell_x, const t_real
     for (t_int m = 0; m < y_size; ++m) {
       const t_real x = (l - x_size * 0.5) * delt_x;
       const t_real y = (m - y_size * 0.5) * delt_y;
-      output(m, l) = dde(y, x);
+      output(m, l) = ((x * x + y * y) < 1) ? dde(y, x) : 0.;
     }
 
   return output;

--- a/cpp/purify/wkernel_integration.cc
+++ b/cpp/purify/wkernel_integration.cc
@@ -17,7 +17,9 @@ t_complex fourier_wproj_kernel(const t_real x, const t_real y, const t_real w, c
 }
 t_complex hankel_wproj_kernel(const t_real r, const t_real w, const t_real u, const t_real v,
                               const t_real du) {
-  return std::exp(t_complex(0., -2 * constant::pi * w * (std::sqrt(1 - (r * r) / (du * du)) - 1))) *
+  return ((r / du < 1.) ? std::exp(t_complex(
+                              0., -2 * constant::pi * w * (std::sqrt(1 - (r * r) / (du * du)) - 1)))
+                        : 1) *
          boost::math::cyl_bessel_j(0, 2 * constant::pi * r * std::sqrt(u * u + v * v)) * r;
 }
 t_complex exact_w_projection_integration_1d(const t_real u, const t_real v, const t_real w,

--- a/cpp/purify/wproj_operators.cc
+++ b/cpp/purify/wproj_operators.cc
@@ -96,7 +96,7 @@ Sparse<t_complex> init_gridding_matrix_2d(const Vector<t_real> &u, const Vector<
                  ? projection_kernels::exact_w_projection_integration_1d(
                        (u(m) - (kwu + ju)), (v(m) - (kwv + jv)), w_val, du, oversample_ratio,
                        ftkernel_radial, max_evaluations, absolute_error, relative_error,
-                       integration::method::p, evaluations)
+                       (du > 1.) ? integration::method::p : integration::method::h, evaluations)
                  : projection_kernels::exact_w_projection_integration(
                        (u(m) - (kwu + ju)), (v(m) - (kwv + jv)), w_val, du, dv, oversample_ratio,
                        ftkernel_radial, ftkernel_radial, max_evaluations, absolute_error,


### PR DESCRIPTION
Fixing coordinates and zero padding breaking when image covers a region greater than the upper hemisphere 