### PR TITLE
Make stable to build a stabilized  SOPT

### DIFF
--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -73,7 +73,7 @@ endif()
 # Unless otherwise specified, if purify is not on master, then sopt will be
 # downloaded from development branch.
 if(NOT Sopt_GIT_TAG)
-  set(Sopt_GIT_TAG development CACHE STRING "Branch/tag when downloading sopt")
+  set(Sopt_GIT_TAG stable CACHE STRING "Branch/tag when downloading sopt")
 endif()
 if(NOT Sopt_GIT_REPOSITORY)
   set(Sopt_GIT_REPOSITORY https://www.github.com/astro-informatics/sopt.git


### PR DESCRIPTION
This change - we hope - can be left untouched on future released and make that when someone builds PURIFY will download the stabilized version of SOPT. On the development branch will download the development version of SOPT.