### PR TITLE
Simulation bug fixes

### DIFF
--- a/cpp/main.cc
+++ b/cpp/main.cc
@@ -119,7 +119,7 @@ int main(int argc, const char **argv) {
                                std::to_string(params.height()) + ").");
     t_int const number_of_pixels = image.size();
     t_int const number_of_vis = params.number_of_measurements();
-    t_real const sigma_m = constant::pi / 3;
+    t_real const sigma_m = constant::pi / 4;
     const t_real rms_w = params.w_rms();  // lambda
     if (params.measurements().at(0) == "") {
       uv_data = utilities::random_sample_density(number_of_vis, 0, sigma_m, rms_w);

--- a/cpp/main.cc
+++ b/cpp/main.cc
@@ -192,7 +192,7 @@ int main(int argc, const char **argv) {
       "{}\"x{}\".",
       params.cellsizey(), params.cellsizex(), ideal_cell_y, ideal_cell_x);
   t_real const flux_scale =
-      (uv_data.units == utilities::vis_units::lambda)
+      (params.source() == purify::utilities::vis_source::measurements)
           ? widefield::pixel_to_lambda(params.cellsizex(), params.width(), params.oversampling()) *
                 widefield::pixel_to_lambda(params.cellsizey(), params.height(),
                                            params.oversampling())


### PR DESCRIPTION
The units for field of view were being scaled when the measurement units were in lambda. But, this is not needed for simulations. Scaling only now happens for real data not simulations.

Sampling pattern range was too big in the simulations causing the PSF to be unrealistic in some cases. `pi/3` should be at most `pi/4` (`pi/6` would also be okay).