### PR TITLE
Migrate CI to Github Actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,10 +29,10 @@ jobs:
             - ubuntu-20.04
             - macos-11
           cc:
-            - gcc
+            - gcc-9
             - clang
           cxx:
-            - g++
+            - g++-9
             - clang++
           mpi:
             - "ON"
@@ -41,10 +41,10 @@ jobs:
             - "ON"
             - "OFF"
           exclude:
-            - cc: gcc
+            - cc: gcc-9
               cxx: clang++
             - cc: clang
-              cxx: g++
+              cxx: g++-9
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,6 +45,9 @@ jobs:
               cxx: clang++
             - cc: clang
               cxx: g++-9
+            - os: ubuntu-20.04
+              cc: clang
+              cxx: clang++
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,7 +77,7 @@ jobs:
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_VERBOSE_MAKEFILE;BOOL=ON \
+        -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
         -Ddompi=${{matrix.mpi}} -Dopenmp=${{matrix.omp}}
 
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,6 +48,9 @@ jobs:
             - os: ubuntu-20.04
               cc: clang
               cxx: clang++
+            - os: macos-11 # Temporary to speed things up
+              cc: clang
+              cxx: clang++
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,38 @@
+name: CMake
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+      

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
       
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel 2
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,6 +20,7 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{matrix.os}}
     env:
+      CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
     strategy:
       fail-fast: false
@@ -27,6 +28,9 @@ jobs:
           os:
             - ubuntu-20.04
             - macos-11
+          cc:
+            - gcc
+            - clang
           cxx:
             - g++
             - clang++
@@ -36,6 +40,11 @@ jobs:
           omp:
             - "ON"
             - "OFF"
+          exclude:
+            - cc: gcc
+              cxx: clang++
+            - cc: clang
+              cxx: g++
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,12 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Dependencies on Ubunutu
+      if: ${{ contains(matrix.os, 'ubuntu') }}
       run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache libcfitsio-dev casacore-dev
+
+    - name: Install Dependencies on MacOS
+      if: ${{ contains(matrix.os, 'macos') }}
+      run: brew install fftw libtiff open-mpi boost eigen libyaml cfitsio ccache
 
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -68,8 +68,8 @@ jobs:
           ${{ matrix.os }}-${{ matrix.cxx }}
           ${{ matrix.os }}
 
-    - name: Clear ccache
-      run: ccache --clear
+#    - name: Clear ccache
+#      run: ccache --clear
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -77,6 +77,7 @@ jobs:
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_VERBOSE_MAKEFILE;BOOL=ON \
         -Ddompi=${{matrix.mpi}} -Dopenmp=${{matrix.omp}}
 
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,21 +22,37 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Dependencies on Ubunutu
-      run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev
+      run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache
 
-      
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+    - name: Set ccache cache directory
+      shell: bash
+      run: echo "CCACHE_DIR=${{runner.workspace}}/.ccache" >> "${GITHUB_ENV}"
+    - name: Cache ccache files
+      uses: actions/cache@v2
+      with:
+        path: ${{runner.workspace}}/.ccache
+        key: ${{ runner.os }}-test-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        restore-keys: |
+          ${{ runner.os }}-test-
+          ${{ runner.os }}-
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-      
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel 2
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
+      # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-      

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Dependencies on Ubunutu
-      run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev
+      run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev
 
       
     - name: Configure CMake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install Dependencies on MacOS
       if: ${{ contains(matrix.os, 'macos') }}
-      run: brew install fftw libtiff open-mpi boost eigen libyaml cfitsio ccache
+      run: brew install fftw libtiff open-mpi boost libyaml cfitsio ccache
 
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp
@@ -67,6 +67,9 @@ jobs:
           ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}
           ${{ matrix.os }}-${{ matrix.cxx }}
           ${{ matrix.os }}
+
+    - name: Clear ccache
+      run: ccache --clear
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,8 @@ jobs:
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{matrix.os}}
-
+    env:
+      CXX: ${{ matrix.cxx }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +42,7 @@ jobs:
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}
-      run: sudo apt install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache libcfitsio-dev casacore-dev; sudo update-ccache-symlinks
+      run: sudo apt install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache libcfitsio-dev casacore-dev
 
     - name: Install Dependencies on MacOS
       if: ${{ contains(matrix.os, 'macos') }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,11 +21,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install Dependencies on Ubunutu
+      run: sudo apt-get install libfftw3-dev libtiff5-dev
+
+      
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-
+      
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,14 +9,32 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  OMP_NUM_THREADS: 4
 
 jobs:
   build:
+    name: ${{matrix.os}}-${{matrix.cxx}}-mpi:${{matrix.mpi}}-openmp:${{matrix.omp}}
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-20.04
+    runs-on: ${{matrix.os}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+          os:
+            - ubuntu-20.04
+            - macos-11
+          cxx:
+            - g++
+            - clang++
+          mpi:
+            - "ON"
+            - "OFF"
+          omp:
+            - "ON"
+            - "OFF"
 
     steps:
     - uses: actions/checkout@v2
@@ -37,15 +55,20 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{runner.workspace}}/.ccache
-        key: ${{ runner.os }}-test-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        key: ${{matrix.os}}-${{matrix.cxx}}-${{matrix.mpi}}-${{matrix.omp}}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
         restore-keys: |
-          ${{ runner.os }}-test-
-          ${{ runner.os }}-
+          ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
+          ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}
+          ${{ matrix.os }}-${{ matrix.cxx }}
+          ${{ matrix.os }}
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -Ddompi=${{matrix.mpi}} -Dopenmp=${{matrix.omp}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Dependencies on Ubunutu
-      run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache
+      run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache libcfitsio-dev casacore-dev
 
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Dependencies on Ubunutu
-      run: sudo apt-get install libfftw3-dev libtiff5-dev
+      run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev
 
       
     - name: Configure CMake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,9 +48,6 @@ jobs:
             - os: ubuntu-20.04
               cc: clang
               cxx: clang++
-            - os: macos-11 # Temporary to speed things up
-              cc: clang
-              cxx: clang++
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}
-      run: sudo apt-get install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache libcfitsio-dev casacore-dev
+      run: sudo apt install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache libcfitsio-dev casacore-dev; sudo update-ccache-symlinks
 
     - name: Install Dependencies on MacOS
       if: ${{ contains(matrix.os, 'macos') }}

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -14,14 +14,6 @@ if(docs)
   endif()
 endif()
 
-# Look for external software
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  find_package(Threads)
-  if(THREADS_FOUND)
-    add_compile_options(-pthread)
-  endif(THREADS_FOUND)
-endif()
-
 # Always find open-mp, since it may be used by sopt
 find_package(OpenMP)
 if(OPENMP_FOUND AND NOT TARGET openmp::openmp)
@@ -56,6 +48,13 @@ if(dompi)
 endif()
 find_package(TIFF REQUIRED)
 
+# Look for external software
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  find_package(Threads)
+  if(THREADS_FOUND AND OPENMP_FOUND)
+    add_compile_options(-pthread)
+  endif(THREADS_FOUND)
+endif()
 
 lookup_package(Boost REQUIRED COMPONENTS filesystem)
 

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -26,15 +26,16 @@ endif()
 find_package(OpenMP)
 if(OPENMP_FOUND AND NOT TARGET openmp::openmp)
   add_library(openmp::openmp INTERFACE IMPORTED GLOBAL)
-  set_target_properties(openmp::openmp PROPERTIES
-    INTERFACE_COMPILE_OPTIONS "${OpenMP_CXX_FLAGS}"
-    INTERFACE_LINK_LIBRARIES  "${OpenMP_CXX_FLAGS}")
 endif()
 if(openmp AND NOT OPENMP_FOUND)
   message(STATUS "Could not find OpenMP. Compiling without.")
 endif()
 set(PURIFY_OPENMP_FFTW FALSE)
 if(openmp AND OPENMP_FOUND)
+  set_target_properties(openmp::openmp PROPERTIES
+    INTERFACE_COMPILE_OPTIONS "${OpenMP_CXX_FLAGS}"
+    INTERFACE_LINK_LIBRARIES  "${OpenMP_CXX_FLAGS}")
+
   set(PURIFY_OPENMP TRUE)
   find_package(FFTW3 REQUIRED DOUBLE SERIAL COMPONENTS OPENMP)
   set(FFTW3_DOUBLE_LIBRARY fftw3::double::serial)

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -14,6 +14,14 @@ if(docs)
   endif()
 endif()
 
+# Look for external software
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  find_package(Threads)
+  if(THREADS_FOUND)
+    add_compile_options(-pthread)
+  endif(THREADS_FOUND)
+endif()
+
 # Always find open-mp, since it may be used by sopt
 find_package(OpenMP)
 if(OPENMP_FOUND AND NOT TARGET openmp::openmp)
@@ -48,13 +56,6 @@ if(dompi)
 endif()
 find_package(TIFF REQUIRED)
 
-# Look for external software
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  find_package(Threads)
-  if(THREADS_FOUND AND OPENMP_FOUND)
-    add_compile_options(-pthread)
-  endif(THREADS_FOUND)
-endif()
 
 lookup_package(Boost REQUIRED COMPONENTS filesystem)
 

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -26,6 +26,9 @@ endif()
 find_package(OpenMP)
 if(OPENMP_FOUND AND NOT TARGET openmp::openmp)
   add_library(openmp::openmp INTERFACE IMPORTED GLOBAL)
+  set_target_properties(openmp::openmp PROPERTIES
+    INTERFACE_COMPILE_OPTIONS "-pthread"
+    INTERFACE_LINK_LIBRARIES  "${CMAKE_THREAD_LIBS_INIT}")
 endif()
 if(openmp AND NOT OPENMP_FOUND)
   message(STATUS "Could not find OpenMP. Compiling without.")


### PR DESCRIPTION
This PR creates a `.github/workflows/cmake.yaml` script that runs the CI jobs on Github Actions. The CI jobs are a matrix of 
- os: Ubuntu, MacOS
- compiler: gnu, clang
- MPI: on, off
- OpenMP: on, off

The Ubuntu/clang combination is currently excluded because of #292. Currently it builds all 8 combinations on MacOS which may be a bit overkill, given that MacOS time is theoretically more expensive (although all time is free for public repos). Then again building all combinations catches some bugs, see below. Comments welcome.

I had to make some changes to the build system in `cmake_files/dependencies.cmake` to build with OpenMP=OFF. Adding the `-fopenmp` flat when OpenMP was set to OFF was causing problems so it is now only set when we build with OpenMP=ON. However, it seems that we need to link with `libpthread` when not using OpenMP, that is now provided explicitly. All the builds pass but this seems unnecessarily complex. It is on my TODO list to improve the OpenMP target handling in #297. 

Also not sure whether I should remove the `.travis.yml` file in this PR, or let it keep running as long as we have credits on Travis. Any comments?