### PR TITLE
Simplify compiling with pthreads when OpenMP is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ include(logging)
 # include exernal dependencies
 include(dependencies)
 
+if(NOT PURIFY_OPENMP)
+  set(CMAKE_THREAD_LIBS_INIT "-lpthread")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+endif()
 
 if(tests)  # Adds ctest
   enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ include(logging)
 # include exernal dependencies
 include(dependencies)
 
+# If PURIFY_OPENMP is set to False in dependencies, link libpthread here so that the linker finds it
+# Following advice from https://stackoverflow.com/questions/1620918/cmake-and-libpthread
+
 if(NOT PURIFY_OPENMP)
   set(CMAKE_THREAD_LIBS_INIT "-lpthread")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -29,8 +29,18 @@ if(openmp AND NOT OPENMP_FOUND)
 endif()
 set(PURIFY_OPENMP_FFTW FALSE)
 if(openmp AND OPENMP_FOUND)
+  # Set PURIFY_OPENMP to TRUE when OpenMP is both found and requested
   set(PURIFY_OPENMP TRUE)
+
+  # Add the OpenMP Library
   add_library(openmp::openmp INTERFACE IMPORTED GLOBAL)
+
+  # Set compiler and linker options to the defaults for CXX
+  # TODO: Should this be done automatically?
+  #       Check when we update CMake and the OpenMP linking to
+  #       https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html
+  #       possibly using
+  #       https://cmake.org/cmake/help/latest/module/FindOpenMP.html
   set_target_properties(openmp::openmp PROPERTIES
     INTERFACE_COMPILE_OPTIONS "${OpenMP_CXX_FLAGS}"
     INTERFACE_LINK_LIBRARIES  "${OpenMP_CXX_FLAGS}")
@@ -42,6 +52,7 @@ if(openmp AND OPENMP_FOUND)
     set(PURIFY_OPENMP_FFTW TRUE)
   endif()
 else()
+  # Set to FALSE when OpenMP is not found or not requested
   set(PURIFY_OPENMP FALSE)
   find_package(FFTW3 REQUIRED DOUBLE)
   set(FFTW3_DOUBLE_LIBRARY fftw3::double::serial)

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -24,22 +24,17 @@ endif()
 
 # Always find open-mp, since it may be used by sopt
 find_package(OpenMP)
-if(OPENMP_FOUND AND NOT TARGET openmp::openmp)
-  add_library(openmp::openmp INTERFACE IMPORTED GLOBAL)
-  set_target_properties(openmp::openmp PROPERTIES
-    INTERFACE_COMPILE_OPTIONS "-pthread"
-    INTERFACE_LINK_LIBRARIES  "${CMAKE_THREAD_LIBS_INIT}")
-endif()
 if(openmp AND NOT OPENMP_FOUND)
   message(STATUS "Could not find OpenMP. Compiling without.")
 endif()
 set(PURIFY_OPENMP_FFTW FALSE)
 if(openmp AND OPENMP_FOUND)
+  set(PURIFY_OPENMP TRUE)
+  add_library(openmp::openmp INTERFACE IMPORTED GLOBAL)
   set_target_properties(openmp::openmp PROPERTIES
     INTERFACE_COMPILE_OPTIONS "${OpenMP_CXX_FLAGS}"
     INTERFACE_LINK_LIBRARIES  "${OpenMP_CXX_FLAGS}")
 
-  set(PURIFY_OPENMP TRUE)
   find_package(FFTW3 REQUIRED DOUBLE SERIAL COMPONENTS OPENMP)
   set(FFTW3_DOUBLE_LIBRARY fftw3::double::serial)
   if(TARGET fftw3::double::openmp)


### PR DESCRIPTION
Slightly less obscure way of ensuring we always pass `-pthread` when OpenMP is off. Inspired by https://github.com/astro-informatics/sopt/pull/264