### PR TITLE
Sj/ga migrate linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,43 @@
+name: Linting
+
+on:
+  push:
+    branches: [ sj/ga-migrate-linting ]
+
+  
+jobs:
+  make-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        
+      - run: sudo apt-get update
+    
+      - name: Install dependencies
+        run: sudo apt install libfftw3-dev libtiff5-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev libcfitsio-dev casacore-dev libllvm7 
+    
+      - name: before script #extra dependencies? trusty?
+        run: |
+          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update -y -qq 
+          sudo apt-get install clang-format
+          
+      - name: Configure
+        run: | 
+          mkdir build
+          cd build
+          cmake .. \
+          -Ddompi=OFF \
+          -Dopenmp=OFF \
+          -Ddocs=OFF 
+
+      - name: Build #?
+        run: | 
+          find ../ -regex '.*\.\(cc\|h\)' -not -iname '*.in.h' | xargs -I{} -P 10 clang-format -i -style=file {}; git diff
+          
+      - name: Test # Report results of lint?
+        run: | 
+          git diff --exit-code || (echo '## NOTE: your code is not linted properly - fix the above'; false)
+ 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,5 +39,5 @@ jobs:
           
       - name: Report results
         run: | 
-          git diff --exit-code || (echo '## NOTE: your code is not linted properly - fix the above'; false)
+          git diff --exit-code || (echo '## NOTE: your code is not linted properly - please commit the suggested changes'; false)
  

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,37 +2,24 @@ name: Linting
 
 on:
   push:
-    branches: [ sj/ga-migrate-linting ]
+    branches: [ development ]
+  pull-request:
+    branches: [development]    
 
   
 jobs:
   linting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
         
-      - run: sudo apt-get update
     
       - name: Install dependencies
-        run: sudo apt install libfftw3-dev libtiff5-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev libcfitsio-dev casacore-dev libllvm7 
-    
-      - name: Extra dependencies
         run: |
-          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" | sudo tee -a /etc/apt/sources.list
-          sudo apt-get update -y -qq 
-          sudo apt-get install clang-format
+          sudo apt install clang-format
           
-      - name: Configure
-        run: | 
-          mkdir build
-          cd build
-          cmake .. \
-          -Ddompi=OFF \
-          -Dopenmp=OFF \
-          -Ddocs=OFF 
-
+# Check code meets Google C++ style guide https://google.github.io/styleguide/cppguide.html
       - name: Run linting
         run: | 
           find ../ -regex '.*\.\(cc\|h\)' -not -iname '*.in.h' | xargs -I{} -P 10 clang-format -i -style=file {}; git diff

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,7 +6,7 @@ on:
 
   
 jobs:
-  make-documentation:
+  linting:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt install libfftw3-dev libtiff5-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev libcfitsio-dev casacore-dev libllvm7 
     
-      - name: before script #extra dependencies? trusty?
+      - name: Extra dependencies
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" | sudo tee -a /etc/apt/sources.list
@@ -33,11 +33,11 @@ jobs:
           -Dopenmp=OFF \
           -Ddocs=OFF 
 
-      - name: Build #?
+      - name: Run linting
         run: | 
           find ../ -regex '.*\.\(cc\|h\)' -not -iname '*.in.h' | xargs -I{} -P 10 clang-format -i -style=file {}; git diff
           
-      - name: Test # Report results of lint?
+      - name: Report results
         run: | 
           git diff --exit-code || (echo '## NOTE: your code is not linted properly - fix the above'; false)
  


### PR DESCRIPTION
Check the code complies with C++ standards and makes changes where appropriate.

[This similar example](https://github.com/marketplace/actions/clang-format-lint) suggests adding a step to commit the suggested changes. Do we want to do that or just prompt the user to commit?