### PR TITLE
Make purify code compatible with refactored sopt 

### DIFF
--- a/cpp/purify/algorithm_factory.h
+++ b/cpp/purify/algorithm_factory.h
@@ -189,10 +189,12 @@ fb_factory(const algo_distribution dist,
         .l1_proximal_real_constraint(real_constraint)
         .Psi(*wavelets);
     gp = l1_gp;
+    break;
   }
   case (g_proximal_type::TFGProximal): {
     // Create a shared pointer to an instance of the TFGProximal class
     gp = std::make_shared<sopt::algorithm::TFGProximal<t_scalar>>(model_path);
+    break;
   }
     default: { throw std::runtime_error("Type of g_proximal operator not recognised."); }
   }

--- a/cpp/purify/algorithm_factory.h
+++ b/cpp/purify/algorithm_factory.h
@@ -188,6 +188,11 @@ fb_factory(const algo_distribution dist,
         .l1_proximal_positivity_constraint(positive_constraint)
         .l1_proximal_real_constraint(real_constraint)
         .Psi(*wavelets);
+#ifdef PURIFY_MPI
+    auto const comm = sopt::mpi::Communicator::World();
+    l1_gp->l1_proximal_adjoint_space_comm(comm);
+    l1_gp->l1_proximal_direct_space_comm(comm);
+#endif
     gp = l1_gp;
     break;
   }
@@ -208,7 +213,7 @@ fb_factory(const algo_distribution dist,
 #ifdef PURIFY_MPI
   case (algo_distribution::mpi_serial): {
     auto const comm = sopt::mpi::Communicator::World();
-    // fb->l1_proximal_adjoint_space_comm(comm);
+    fb->adjoint_space_comm(comm);
     fb->obj_comm(comm);
     break;
   }

--- a/cpp/purify/algorithm_factory.h
+++ b/cpp/purify/algorithm_factory.h
@@ -189,9 +189,12 @@ fb_factory(const algo_distribution dist,
         .l1_proximal_real_constraint(real_constraint)
         .Psi(*wavelets);
 #ifdef PURIFY_MPI
-    auto const comm = sopt::mpi::Communicator::World();
-    l1_gp->l1_proximal_adjoint_space_comm(comm);
-    l1_gp->l1_proximal_direct_space_comm(comm);
+    if(dist == algo_distribution::mpi_serial)
+    {
+      auto const comm = sopt::mpi::Communicator::World();
+      l1_gp->l1_proximal_adjoint_space_comm(comm);
+      l1_gp->l1_proximal_direct_space_comm(comm);
+    }
 #endif
     gp = l1_gp;
     break;

--- a/cpp/purify/update_factory.h
+++ b/cpp/purify/update_factory.h
@@ -45,7 +45,7 @@ void add_updater(std::weak_ptr<Algo> const algo_weak, const t_real step_size_sca
       auto algo = algo_weak.lock();
       if (comm.is_root()) PURIFY_MEDIUM_LOG("Step size γ {}", algo->gamma());
       if (algo->gamma() > 0) {
-        Vector<t_complex> const alpha = algo->Psi().adjoint() * x;
+        Vector<t_complex> const alpha = algo->g_proximal()->Psi().adjoint() * x;
         const t_real new_gamma =
             comm.all_reduce((sara_size > 0) ? alpha.real().cwiseAbs().maxCoeff() : 0., MPI_MAX) *
             step_size_scale;
@@ -88,7 +88,7 @@ void add_updater(std::weak_ptr<Algo> const algo_weak, const t_real step_size_sca
       auto algo = algo_weak.lock();
       if (algo->gamma() > 0) {
         PURIFY_MEDIUM_LOG("Step size γ {}", algo->gamma());
-        Vector<T> const alpha = algo->Psi().adjoint() * x;
+        Vector<T> const alpha = algo->g_proximal()->Psi().adjoint() * x;
         const t_real new_gamma = alpha.real().cwiseAbs().maxCoeff() * step_size_scale;
         PURIFY_MEDIUM_LOG("Step size γ update {}", new_gamma);
         // updating parameter

--- a/cpp/purify/yaml-parser.cc
+++ b/cpp/purify/yaml-parser.cc
@@ -225,7 +225,7 @@ void YamlParser::parseAndSetAlgorithmOptions(const YAML::Node& algorithmOptionsN
     this->gProximalType_ = factory::g_proximal_type_string.at(
         get<std::string>(algorithmOptionsNode, {"fb", "gProximalType"}));
     this->model_path_ = 
-        get<std::string>(algorithmOptionsNode, {"fb", "modelPath"}));
+        get<std::string>(algorithmOptionsNode, {"fb", "modelPath"});
     if (this->algorithm_ == "fb_joint_map") {
       this->jmap_iters_ =
           get<t_uint>(algorithmOptionsNode, {"fb", "joint_map_estimation", "iters"});

--- a/cpp/purify/yaml-parser.h
+++ b/cpp/purify/yaml-parser.h
@@ -141,7 +141,7 @@ class YamlParser {
   YAML_MACRO(t_real, jmap_beta, 1)
 
   YAML_MACRO(std::string, model_path, "")
-  YAML_MACRO(factory::g_proximal_type, gProximalType, sopt::algorithm::L1GProximal)
+  YAML_MACRO(factory::g_proximal_type, gProximalType, factory::g_proximal_type::L1GProximal)
 
 #undef YAML_MACRO
  private:


### PR DESCRIPTION
Fix handling on g_proximal type in FB factory 
Assign MPI communicators for L1GProximal 
Access internal components like Psi() through g_proximal 