### PR TITLE
Install boost without fiber and python

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,6 +62,9 @@ jobs:
               cxx: clang++
             - os: macos-11
               mpi: "on"
+            - os: ubuntu-20.04
+            - cxx: clang++
+            - omp: "on"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,9 +62,6 @@ jobs:
               cxx: clang++
             - os: macos-11
               mpi: "on"
-            - os: ubuntu-20.04
-            - cxx: clang++
-            - omp: "on"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,7 +80,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         sudo apt update
-        sudo apt install libfftw3-dev libtiff5-dev openmpi-bin libopenmpi-dev libboost-all-dev libeigen3-dev libyaml-cpp-dev ccache libcfitsio-dev casacore-dev
+        sudo apt install openmpi-bin libopenmpi-dev ccache casacore-dev
 
     - name: Install Dependencies on MacOS
       if: ${{ contains(matrix.os, 'macos') }}
@@ -90,7 +90,7 @@ jobs:
         # brew update is very slow because it's updating a lot of unrelated packages
         # workflow seems to run fine with default versions
         # brew update
-        brew install fftw libtiff open-mpi boost libyaml cfitsio ccache conan
+        brew install open-mpi libomp ccache
         echo "CMAKE_PREFIX_PATH=/usr/local/opt/libomp" >> $GITHUB_ENV
 
     - name: Install Tensorflow API on Ubuntu

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,7 +55,11 @@ class PurifyConan(ConanFile):
         self.options["sopt"].examples = 'off'
         self.options["sopt"].tests = 'off'
 
+        # Exclude boost features we don't need. without_fiber is required when
+        # building from source on MacOS with gcc.
+        # The rest are to speed up building from source.
         self.options["boost"].without_fiber = True
+        self.options["boost"].without_python = True
 
     def requirements(self):
         # To prevent a conflict in the version of zlib required by libtiff and

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,6 +55,8 @@ class PurifyConan(ConanFile):
         self.options["sopt"].examples = 'off'
         self.options["sopt"].tests = 'off'
 
+        self.options["boost"].without_fiber = True
+
     def requirements(self):
         # To prevent a conflict in the version of zlib required by libtiff and
         # doxygen, override the version of zlib when either of them is required


### PR DESCRIPTION
Closes #320 

Added the `without_fiber` option to boost and the rest of it seems to build. 

I also noticed we are apt/brew installing a lot of dependencies that are installed by conan, removed the duplicates. 

I expect the apple-clang builds to still fail, but #327 addresses that