### PR TITLE
Fix/work-around errors in apple-clang

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,6 +62,8 @@ jobs:
               cxx: clang++
             - os: macos-11
               mpi: "on"
+            - cxx: clang++
+              omp: "on"
 
     steps:
     - uses: actions/checkout@v3

--- a/cpp/purify/integration.cc
+++ b/cpp/purify/integration.cc
@@ -1,4 +1,5 @@
 #include "purify/integration.h"
+#include <array>
 
 namespace purify {
 namespace integration {

--- a/cpp/purify/integration.cc
+++ b/cpp/purify/integration.cc
@@ -41,8 +41,8 @@ t_complex integrate(const Vector<t_real> &xmin, const Vector<t_real> &xmax,
                     const t_real required_abs_error, const t_real required_rel_error,
                     const t_uint max_evaluations, const method methodtype) {
   assert(xmin.size() == xmax.size());
-  std::array<t_real, 2> val{{0., 0.}};
-  std::array<t_real, 2> err{{0., 0.}};
+  std::array<t_real, 2> val = {0., 0.};
+  std::array<t_real, 2> err = {0., 0.};
   auto wrap_integrand = [](unsigned ndim, const t_real *x, void *fdata, unsigned fdim,
                            double *fval) -> int {
     assert(fdim == 2);

--- a/cpp/purify/integration.cc
+++ b/cpp/purify/integration.cc
@@ -42,8 +42,8 @@ t_complex integrate(const Vector<t_real> &xmin, const Vector<t_real> &xmax,
                     const t_real required_abs_error, const t_real required_rel_error,
                     const t_uint max_evaluations, const method methodtype) {
   assert(xmin.size() == xmax.size());
-  std::array<t_real, 2> val = {0., 0.};
-  std::array<t_real, 2> err = {0., 0.};
+  std::array<t_real, 2> val{0., 0.};
+  std::array<t_real, 2> err{0., 0.};
   auto wrap_integrand = [](unsigned ndim, const t_real *x, void *fdata, unsigned fdim,
                            double *fval) -> int {
     assert(fdim == 2);


### PR DESCRIPTION
Closes #321 

OpenMP in apple-clang is problematic, therefore drop apple-clang OpenMP build from the CI matrix.

Changed the array initialisation syntax in integration.cc. Although [cppreference](https://en.cppreference.com/w/cpp/container/array) says both ways should work in C++11, they recommend initialising with `array<t,n> foo = {1,2,3}` rather than `array<t,n>foo{{1,2,3}}`. Added `#include <array>` which was the cause of the problem. https://stackoverflow.com/questions/12797051/implicit-instantiation-of-undefined-template-when-forward-declaring-template-c