### PR TITLE
Reduce retention period of uploaded artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       with:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
         path: ${{github.workspace}}/local
-
+        retention-days: 5
 
   test:
     needs:


### PR DESCRIPTION
By default GitHub stores uploaded artifacts for 90 days. We generate about 25MB of artifacts per CI run which is not huge, but I can't think of any need to store them. They are just installed libraries. 5 days seems like a more reasonable number.