### PR TITLE
Preserve symlinks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,13 @@ jobs:
         cmake .. --fresh -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/local -Ddompi=${{matrix.mpi}} -Dopenmp=${{matrix.omp}} -Dtests=OFF -Dexamples=OFF
         make -j$(nproc --ignore 1) install
 
+    - name: Pack dependencies
+      run: tar cf ${{github.workspace}}/dependencies.tar ${{github.workspace}}/local
+        
     - uses: actions/upload-artifact@v4
       with:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
-        path: ${{github.workspace}}/local
+        path: ${{github.workspace}}/dependencies.tar
         retention-days: 5
 
   test:
@@ -188,7 +191,9 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
-        path: ${{github.workspace}}/local
+
+    -name: Unpack dependencies
+        run: tar xf dependencies.tar
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -247,7 +252,9 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
-        path: ${{github.workspace}}/local
+
+    -name: Unpack dependencies
+        run: tar xf dependencies.tar
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,9 @@ jobs:
         make -j$(nproc --ignore 1) install
 
     - name: Pack dependencies
-      run: tar cfv ${{github.workspace}}/dependencies.tar ${{github.workspace}}/local
+      run: |
+        cd ${{github.workspace}}
+        tar cfv dependencies.tar local
         
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,8 @@ jobs:
       with:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
 
-    -name: Unpack dependencies
-     run: tar xf dependencies.tar
+    - name: Unpack dependencies
+      run: tar xf dependencies.tar
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -253,8 +253,8 @@ jobs:
       with:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
 
-    -name: Unpack dependencies
-     run: tar xf dependencies.tar
+    - name: Unpack dependencies
+      run: tar xf dependencies.tar
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         make -j$(nproc --ignore 1) install
 
     - name: Pack dependencies
-      run: tar cf ${{github.workspace}}/dependencies.tar ${{github.workspace}}/local
+      run: tar cfv ${{github.workspace}}/dependencies.tar ${{github.workspace}}/local
         
     - uses: actions/upload-artifact@v4
       with:
@@ -193,7 +193,7 @@ jobs:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
 
     - name: Unpack dependencies
-      run: tar xf dependencies.tar
+      run: tar xfv dependencies.tar
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -254,7 +254,7 @@ jobs:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
 
     - name: Unpack dependencies
-      run: tar xf dependencies.tar
+      run: tar xfv dependencies.tar
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
 
     -name: Unpack dependencies
-        run: tar xf dependencies.tar
+     run: tar xf dependencies.tar
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -254,7 +254,7 @@ jobs:
         name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
 
     -name: Unpack dependencies
-        run: tar xf dependencies.tar
+     run: tar xf dependencies.tar
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
Tar:ing the dependencies directory preserves the symlinks and avoids https://github.com/actions/upload-artifact/issues/590