### PR TITLE
cpp/purify/config.in.h: Add #cmakedefine PURIFY_ONNXRT

### DIFF
--- a/cpp/purify/config.in.h
+++ b/cpp/purify/config.in.h
@@ -16,6 +16,9 @@
 //! Whether PURIFY is running with mpi
 #cmakedefine PURIFY_MPI
 
+//! Whether PURIFY is running with onnxrt (onnxruntime)
+#cmakedefine PURIFY_ONNXRT
+
 //! Whether PURIFY is running with arrayfire
 #cmakedefine PURIFY_ARRAYFIRE
 


### PR DESCRIPTION
@tkoskela @20DM:

To enable onnxrt (onnxruntime) supporting the compiled C++ code, PURIFY_ONNXRT must be defined at the preprocessor level:

https://github.com/astro-informatics/purify/blob/development/cpp/purify/algorithm_factory.h#L27
https://github.com/astro-informatics/purify/blob/development/cpp/purify/algorithm_factory.h#L204
(these are the only places that I found)

This string is found in `bin/purify` if the ONNXRT code is not compiled:
https://github.com/astro-informatics/purify/blob/development/cpp/purify/algorithm_factory.h#L210

On the cmake level, it is set here:
https://github.com/astro-informatics/purify/blob/development/cmake_files/dependencies.cmake#L37

But it needs to be conditinally defined in config.h(.in) to reach the C++ level (actual compilation):

```py
//! Whether PURIFY is running with onnxrt (onnxruntime)
#cmakedefine PURIFY_ONNXRT
```

Without this, even with `cmake -Donnxrt=ON`, `strings bin/purify | grep onnxrt` will find a string that is compiled only when PURIFY_ONNXRT is not set by config.h (and it is not if this cmakedefine is not set).

PS: I noticed this in an extended review of https://github.com/spack/spack/pull/46839

PPS: With this, PURIFY_ONNXRT is set, onnxrt code gets included in the build, but compilation with gcc-13.1.0 fails with these errors:
```py
In file included from /home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:8,
                 from /home/bkaindl/spack/.stage/spack-stage-purify-4.2.0-c7wp4nh7gjtj4boaiucjlzq2ljlf2vjl/spack-src/cpp/purify/algorithm_factory.h:28,
                 from /home/bkaindl/spack/.stage/spack-stage-purify-4.2.0-c7wp4nh7gjtj4boaiucjlzq2ljlf2vjl/spack-src/cpp/tests/algo_factory.cc:12:
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/ort_session.h: In instantiation of 'sopt::Vector<SCALAR> sopt::ORTsession::compute(sopt::Vector<SCALAR>&, const std::vector<long int>&) const [with T = std::complex<double>; sopt::Vector<SCALAR> = Eigen::Matrix<std::complex<double>, -1, 1>]':
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:78:31:   required from 'void sopt::algorithm::TFGProximal<SCALAR>::call_model(t_Vector&, const t_Vector&) const [with SCALAR = std::complex<double>; t_Vector = Eigen::Matrix<std::complex<double>, -1, 1>]'
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:56:15:   required from 'sopt::algorithm::TFGProximal<SCALAR>::t_Proximal sopt::algorithm::TFGProximal<SCALAR>::proximal_function() const [with SCALAR = std::complex<double>; t_Proximal = std::function<void(Eigen::Matrix<std::complex<double>, -1, 1>&, double, const Eigen::Matrix<std::complex<double>, -1, 1>&)>]'
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:54:14:   required from here
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/ort_session.h:81:21: error: cannot convert 'const std::complex<double>' to '__gnu_cxx::__alloc_traits<std::allocator<float>, float>::value_type' {aka 'float'} in assignment
   81 |       flat_input[i] = input[i];
In file included from /home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:8,
                 from /home/bkaindl/spack/.stage/spack-stage-purify-4.2.0-c7wp4nh7gjtj4boaiucjlzq2ljlf2vjl/spack-src/cpp/purify/algorithm_factory.h:28,
                 from /home/bkaindl/spack/.stage/spack-stage-purify-4.2.0-c7wp4nh7gjtj4boaiucjlzq2ljlf2vjl/spack-src/cpp/tests/mpi_algo_factory.cc:19:
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/ort_session.h: In instantiation of 'sopt::Vector<SCALAR> sopt::ORTsession::compute(sopt::Vector<SCALAR>&, const std::vector<long int>&) const [with T = std::complex<double>; sopt::Vector<SCALAR> = Eigen::Matrix<std::complex<double>, -1, 1>]':
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:78:31:   required from 'void sopt::algorithm::TFGProximal<SCALAR>::call_model(t_Vector&, const t_Vector&) const [with SCALAR = std::complex<double>; t_Vector = Eigen::Matrix<std::complex<double>, -1, 1>]'
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:56:15:   required from 'sopt::algorithm::TFGProximal<SCALAR>::t_Proximal sopt::algorithm::TFGProximal<SCALAR>::proximal_function() const [with SCALAR = std::complex<double>; t_Proximal = std::function<void(Eigen::Matrix<std::complex<double>, -1, 1>&, double, const Eigen::Matrix<std::complex<double>, -1, 1>&)>]'
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:54:14:   required from here
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/ort_session.h:81:21: error: cannot convert 'const std::complex<double>' to '__gnu_cxx::__alloc_traits<std::allocator<float>, float>::value_type' {aka 'float'} in assignment
   81 |       flat_input[i] = input[i];
In file included from /home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:8,
                 from /home/bkaindl/spack/.stage/spack-stage-purify-4.2.0-c7wp4nh7gjtj4boaiucjlzq2ljlf2vjl/spack-src/cpp/purify/algorithm_factory.h:28,
                 from /home/bkaindl/spack/.stage/spack-stage-purify-4.2.0-c7wp4nh7gjtj4boaiucjlzq2ljlf2vjl/spack-src/cpp/main.cc:8:
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/ort_session.h: In instantiation of 'sopt::Vector<SCALAR> sopt::ORTsession::compute(sopt::Vector<SCALAR>&, const std::vector<long int>&) const [with T = std::complex<double>; sopt::Vector<SCALAR> = Eigen::Matrix<std::complex<double>, -1, 1>]':
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:78:31:   required from 'void sopt::algorithm::TFGProximal<SCALAR>::call_model(t_Vector&, const t_Vector&) const [with SCALAR = std::complex<double>; t_Vector = Eigen::Matrix<std::complex<double>, -1, 1>]'
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:56:15:   required from 'sopt::algorithm::TFGProximal<SCALAR>::t_Proximal sopt::algorithm::TFGProximal<SCALAR>::proximal_function() const [with SCALAR = std::complex<double>; t_Proximal = std::function<void(Eigen::Matrix<std::complex<double>, -1, 1>&, double, const Eigen::Matrix<std::complex<double>, -1, 1>&)>]'
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/tf_g_proximal.h:54:14:   required from here
/home/bkaindl/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/sopt-4.2.0-5spnatotqxu442pewzbqqxmz7wsurmr6/include/sopt/ort_session.h:81:21: error: cannot convert 'const std::complex<double>' to '__gnu_cxx::__alloc_traits<std::allocator<float>, float>::value_type' {aka 'float'} in assignment
   81 |       flat_input[i] = input[i];
```

This used py-onnxruntime@1.18.2 and sopt@4.2.0