### PR TITLE
add Homebrew lib dir to lib path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,8 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
         export LD_LIBRARY_PATH=${{github.workspace}}/local/lib:${{github.workspace}}/local/external/lib:${LD_LIBRARY_PATH}
+        export DYLD_LIBRARY_PATH=${{github.workspace}}/local/lib:${{github.workspace}}/local/external/lib:${DYLD_LIBRARY_PATH}
+        export DYLD_LIBRARY_PATH=$(brew --prefix)/lib:${DYLD_LIBRARY_PATH}
         ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
   doc:


### PR DESCRIPTION
In response to recent CI failures for MacOS.