### PR TITLE
Add a CI job to build dependencies and benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
             - clang++
           mpi:
             - "ON"
+            - "OFF"
           omp:
             - "ON"
           exclude:
@@ -272,6 +273,10 @@ jobs:
               cc: gcc-12
             - os: macos-14
               cxx: g++-12
+            - os: macos-14
+              mpi: "ON"
+            - os: ubuntu-22.04
+              mpi: "OFF"
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,12 +290,12 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         sudo apt update
-        sudo apt install openmpi-bin libopenmpi-dev ccache graphviz libeigen3-dev libtiff-dev libcfitsio-dev libboost-all-dev libyaml-cpp-dev
+        sudo apt install openmpi-bin libopenmpi-dev ccache graphviz libeigen3-dev libtiff-dev libcfitsio-dev libboost-all-dev libyaml-cpp-dev libbenchmark-dev
 
     - name: Install Dependencies on MacOS
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
-        brew install open-mpi libomp eigen ccache cfitsio boost yaml-cpp onnxruntime
+        brew install open-mpi libomp eigen ccache cfitsio boost yaml-cpp onnxruntime google-benchmark
         echo "CMAKE_PREFIX_PATH=/opt/homebrew/opt/libomp" >> $GITHUB_ENV
         echo "/opt/homebrew/opt/ccache/libexec" >> $GITHUB_PATH
 
@@ -303,7 +303,6 @@ jobs:
       # Build your program with the given configuration
       run: |
         export CMAKE_PREFIX_PATH=${{github.workspace}}/local:$CMAKE_PREFIX_PATH
-        #export PATH=${{github.workspace}}/local:$PATH
         mkdir -p ${{github.workspace}}/build
         cd ${{github.workspace}}/build
         cmake .. --fresh -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/local -Donnxrt=ON -Dhdf5=ON -Ddocasa=OFF -Ddompi=${{matrix.mpi}} -Dopenmp=${{matrix.omp}} -Dtests=OFF -Dexamples=ON -Dbenchmarks=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ env:
   OMP_NUM_THREADS: 2
 
 jobs:
-  build:
+  dependencies:
     # Skip CI if PR is a draft
     if: github.event.pull_request.draft == false
-    name: build (${{matrix.os}}-${{matrix.cxx}}-mpi:${{matrix.mpi}}-openmp:${{matrix.omp}})
+    name: dependencies (${{matrix.os}}-${{matrix.cxx}}-mpi:${{matrix.mpi}}-openmp:${{matrix.omp}})
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -161,7 +161,7 @@ jobs:
 
   test:
     needs:
-      build
+      dependencies
     name: test (${{matrix.os}}-${{matrix.cxx}}-mpi:${{matrix.mpi}}-openmp:${{matrix.omp}})
     runs-on: ${{matrix.os}}
     env:
@@ -239,9 +239,75 @@ jobs:
         export DYLD_LIBRARY_PATH=$(brew --prefix)/lib:${DYLD_LIBRARY_PATH}
         ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
+  examples_benchmarks:
+    needs:
+      dependencies
+    name: examples_benchmarks (${{matrix.os}}-${{matrix.cxx}}-mpi:${{matrix.mpi}}-openmp:${{matrix.omp}})
+    runs-on: ${{matrix.os}}
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+    strategy:
+      fail-fast: false
+      matrix:
+          os:
+            - ubuntu-22.04
+            - macos-14
+          cc:
+            - gcc-12
+            - clang
+          cxx:
+            - g++-12
+            - clang++
+          mpi:
+            - "ON"
+          omp:
+            - "ON"
+          exclude:
+            - os: ubuntu-22.04
+              cc: clang
+            - os: ubuntu-22.04
+              cxx: clang++
+            - os: macos-14
+              cc: gcc-12
+            - os: macos-14
+              cxx: g++-12
+
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: dependencies-${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.mpi }}-${{ matrix.omp }}
+
+    - name: Unpack dependencies
+      run: tar xfv dependencies.tar
+    - name: Install Dependencies on Ubunutu
+      if: ${{ contains(matrix.os, 'ubuntu') }}
+      run: |
+        sudo apt update
+        sudo apt install openmpi-bin libopenmpi-dev ccache graphviz libeigen3-dev libtiff-dev libcfitsio-dev libboost-all-dev libyaml-cpp-dev
+
+    - name: Install Dependencies on MacOS
+      if: ${{ contains(matrix.os, 'macos') }}
+      run: |
+        brew install open-mpi libomp eigen ccache cfitsio boost yaml-cpp onnxruntime
+        echo "CMAKE_PREFIX_PATH=/opt/homebrew/opt/libomp" >> $GITHUB_ENV
+        echo "/opt/homebrew/opt/ccache/libexec" >> $GITHUB_PATH
+
+    - name: Build examples
+      # Build your program with the given configuration
+      run: |
+        export CMAKE_PREFIX_PATH=${{github.workspace}}/local:$CMAKE_PREFIX_PATH
+        #export PATH=${{github.workspace}}/local:$PATH
+        mkdir -p ${{github.workspace}}/build
+        cd ${{github.workspace}}/build
+        cmake .. --fresh -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/local -Donnxrt=ON -Dhdf5=ON -Ddocasa=OFF -Ddompi=${{matrix.mpi}} -Dopenmp=${{matrix.omp}} -Dtests=OFF -Dexamples=ON -Dbenchmarks=ON
+        make -j$(nproc --ignore 1) install
+
+      
   doc:
     needs:
-      build
+      dependencies
     name: doc (${{matrix.os}}-${{matrix.cxx}}-mpi:${{matrix.mpi}}-openmp:${{matrix.omp}})
     runs-on: ${{matrix.os}}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,11 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         sudo apt update
-        sudo apt install openmpi-bin libopenmpi-dev ccache graphviz libeigen3-dev libtiff-dev libcfitsio-dev libboost-all-dev libyaml-cpp-dev libbenchmark-dev
+        sudo apt install openmpi-bin libopenmpi-dev ccache graphviz libeigen3-dev libtiff-dev libcfitsio-dev libboost-all-dev libyaml-cpp-dev
+        wget https://github.com/google/benchmark/archive/refs/tags/v1.8.5.tar.gz -O- | tar --no-same-owner -xz;
+        cd benchmark-1.8.5
+        cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/local -S . -B "build"
+        cmake --build "build" --config Release --target install
 
     - name: Install Dependencies on MacOS
       if: ${{ contains(matrix.os, 'macos') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         export DYLD_LIBRARY_PATH=$(brew --prefix)/lib:${DYLD_LIBRARY_PATH}
         ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
-  examplesBenchmarks:
+  examples_benchmarks:
     needs:
       dependencies
     name: examples_benchmarks (${{matrix.os}}-${{matrix.cxx}}-mpi:${{matrix.mpi}}-openmp:${{matrix.omp}})
@@ -272,7 +272,7 @@ jobs:
               cc: gcc-12
             - os: macos-14
               cxx: g++-12
-
+    steps:
     - uses: actions/checkout@v4
 
     - uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         export DYLD_LIBRARY_PATH=$(brew --prefix)/lib:${DYLD_LIBRARY_PATH}
         ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
-  examples_benchmarks:
+  examplesBenchmarks:
     needs:
       dependencies
     name: examples_benchmarks (${{matrix.os}}-${{matrix.cxx}}-mpi:${{matrix.mpi}}-openmp:${{matrix.omp}})

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -70,8 +70,7 @@ if(tests OR examples)
 endif()
 
 if(benchmarks)
-  find_package(benchmark REQUIRED)
-  #include(AddBenchmark)
+  find_package(benchmark REQUIRED CONFIG)
 endif()
 
 # Always find open-mp, since it may be used by sopt

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -1,15 +1,19 @@
-include_directories("${PROJECT_SOURCE_DIR}/cpp" "${CMAKE_CURRENT_BINARY_DIR}/include")
+include_directories("${PROJECT_SOURCE_DIR}/cpp" "${CMAKE_CURRENT_BINARY_DIR}/include" "${benchmark_DIR}/include")
 
 add_executable(measurement_operator utilities.cc measurement_operator.cc)
-target_link_libraries(measurement_operator benchmark libpurify)
+target_link_libraries(measurement_operator benchmark::benchmark libpurify)
+
 add_executable(algorithms utilities.cc algorithms.cc)
-target_link_libraries(algorithms benchmark libpurify)
+target_link_libraries(algorithms benchmark::benchmark libpurify)
+
 add_executable(wavelet_operator utilities.cc wavelet_operator.cc)
-target_link_libraries(wavelet_operator benchmark libpurify)
+target_link_libraries(wavelet_operator benchmark::benchmark libpurify)
+
 add_executable(fft utilities.cc fft.cc)
-target_link_libraries(fft benchmark libpurify)
+target_link_libraries(fft benchmark::benchmark libpurify)
+
 add_executable(degridding utilities.cc degridding.cc)
-target_link_libraries(degridding benchmark libpurify)
+target_link_libraries(degridding benchmark::benchmark libpurify)
 
 # Skip ArrayFire benchmarks for now, add back later if needed
 # if(doaf)
@@ -20,15 +24,15 @@ target_link_libraries(degridding benchmark libpurify)
 
 if(dompi)
   add_executable(mpi_benchmark_MO main.cc utilities.cc measurement_operator_mpi.cc)
-  target_link_libraries(mpi_benchmark_MO ${MPI_LIBRARIES} benchmark libpurify)
+  target_link_libraries(mpi_benchmark_MO ${MPI_LIBRARIES} benchmark::benchmark libpurify)
   #target_include_directories(mpi_benchmark_MO PUBLIC "${PROJECT_SOURCE_DIR}/cpp" "${CMAKE_CURRENT_BINARY_DIR}/include")
   add_executable(mpi_benchmark_MO_wproj main.cc utilities.cc measurement_operator_wproj.cc)
-  target_link_libraries(mpi_benchmark_MO_wproj ${MPI_LIBRARIES} benchmark libpurify)
+  target_link_libraries(mpi_benchmark_MO_wproj ${MPI_LIBRARIES} benchmark::benchmark libpurify)
   #target_include_directories(mpi_benchmark_MO_wproj PUBLIC "${PROJECT_SOURCE_DIR}/cpp" "${CMAKE_CURRENT_BINARY_DIR}/include")
   add_executable(mpi_benchmark_algorithms main.cc utilities.cc algorithms_mpi.cc)
-  target_link_libraries(mpi_benchmark_algorithms ${MPI_LIBRARIES} benchmark libpurify)
+  target_link_libraries(mpi_benchmark_algorithms ${MPI_LIBRARIES} benchmark::benchmark libpurify)
   #target_include_directories(mpi_benchmark_PADMM PUBLIC "${PROJECT_SOURCE_DIR}/cpp" "${CMAKE_CURRENT_BINARY_DIR}/include")
   add_executable(mpi_benchmark_WLO main.cc utilities.cc wavelet_operator_mpi.cc)
-  target_link_libraries(mpi_benchmark_WLO ${MPI_LIBRARIES} benchmark libpurify)
+  target_link_libraries(mpi_benchmark_WLO ${MPI_LIBRARIES} benchmark::benchmark libpurify)
   #target_include_directories(mpi_benchmark_WLO PUBLIC "${PROJECT_SOURCE_DIR}/cpp" "${CMAKE_CURRENT_BINARY_DIR}/include")
 endif()

--- a/cpp/benchmarks/algorithms.cc
+++ b/cpp/benchmarks/algorithms.cc
@@ -70,8 +70,7 @@ BENCHMARK_DEFINE_F(AlgoFixture, Padmm)(benchmark::State &state) {
 
   m_padmm = factory::padmm_factory<sopt::algorithm::ImagingProximalADMM<t_complex>>(
       factory::algo_distribution::serial, m_measurements_transform, wavelets, m_uv_data, m_sigma,
-      m_imsizey, m_imsizex, m_sara.size(), state.range(3) + 1, true, true, false, 1e-3, 1e-2, 50,
-      1.0);
+      m_imsizey, m_imsizex, m_sara.size(), state.range(3) + 1, true, true, false, 1e-3, 1e-2, 50);
 
   while (state.KeepRunning()) {
     auto start = std::chrono::high_resolution_clock::now();
@@ -115,7 +114,7 @@ BENCHMARK_DEFINE_F(AlgoFixture, ForwardBackwardOnnx)(benchmark::State &state) {
   m_fb = factory::fb_factory<sopt::algorithm::ImagingForwardBackward<t_complex>>(
       factory::algo_distribution::serial, m_measurements_transform, wavelets, m_uv_data, m_sigma,
       beta, gamma, m_imsizey, m_imsizex, m_sara.size(), state.range(3) + 1, true, true, false, 1e-3,
-      1e-2, 50, 1.0, tf_model_path, nondiff_func_type::Denoiser);
+      1e-2, 50, tf_model_path, nondiff_func_type::Denoiser);
 
   while (state.KeepRunning()) {
     auto start = std::chrono::high_resolution_clock::now();

--- a/cpp/benchmarks/algorithms_mpi.cc
+++ b/cpp/benchmarks/algorithms_mpi.cc
@@ -90,7 +90,7 @@ BENCHMARK_DEFINE_F(AlgoFixtureMPI, PadmmDistributeImage)(benchmark::State &state
   m_padmm = factory::padmm_factory<sopt::algorithm::ImagingProximalADMM<t_complex>>(
       factory::algo_distribution::mpi_distributed, m_measurements_distribute_image, wavelets,
       m_uv_data, m_sigma, m_imsizey, m_imsizex, m_sara.size(), state.range(3) + 1, true, true,
-      false, 1e-3, 1e-2, 50, 1.0);
+      false, 1e-3, 1e-2, 50);
 
   // Benchmark the application of the algorithm
   while (state.KeepRunning()) {
@@ -111,7 +111,7 @@ BENCHMARK_DEFINE_F(AlgoFixtureMPI, PadmmDistributeGrid)(benchmark::State &state)
   m_padmm = factory::padmm_factory<sopt::algorithm::ImagingProximalADMM<t_complex>>(
       factory::algo_distribution::mpi_distributed, m_measurements_distribute_grid, wavelets,
       m_uv_data, m_sigma, m_imsizey, m_imsizex, m_sara.size(), state.range(3) + 1, true, true,
-      false, 1e-3, 1e-2, 50, 1.0);
+      false, 1e-3, 1e-2, 50);
 
   // Benchmark the application of the algorithm
   while (state.KeepRunning()) {
@@ -188,7 +188,7 @@ BENCHMARK_DEFINE_F(AlgoFixtureMPI, FbOnnxDistributeImage)(benchmark::State &stat
   m_fb = factory::fb_factory<sopt::algorithm::ImagingForwardBackward<t_complex>>(
       factory::algo_distribution::mpi_serial, m_measurements_distribute_image, wavelets, m_uv_data,
       m_sigma, beta, gamma, m_imsizey, m_imsizex, m_sara.size(), state.range(3) + 1, true, true,
-      false, 1e-3, 1e-2, 50, 1.0, tf_model_path, nondiff_func_type::Denoiser);
+      false, 1e-3, 1e-2, 50, tf_model_path, nondiff_func_type::Denoiser);
 
   // Benchmark the application of the algorithm
   while (state.KeepRunning()) {


### PR DESCRIPTION
Adds a CI job to build the tests and examples. Clarifies names of the CI jobs a bit to make it easier to tell what is being done.

I don't think we need to use resources to run these, the tests should catch most run time bugs.